### PR TITLE
adds a --force option to override existing projects

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                spacchetti-cli
-version:             0.2.0.0
+version:             0.2.1.0
 github:              "justinwoo/spacchetti-cli"
 license:             BSD3
 author:              "Justin Woo"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                spacchetti-cli
-version:             0.2.1.0
+version:             0.2.0.0
 github:              "justinwoo/spacchetti-cli"
 license:             BSD3
 author:              "Justin Woo"


### PR DESCRIPTION
With this pr, `spacchetti local-setup` exits with an error in case of existing `packages.dhall` or `psc-package.json` files.

A `--force` option has been added to overwrite existing projects.

There's a bit of a lazy implementation of a `unsafePathToText` to print file paths in the error message, but I suppose it's good enough for now.