### PR TITLE
aeson + psc-package upgrade

### DIFF
--- a/app/Templates.hs
+++ b/app/Templates.hs
@@ -1,12 +1,31 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TemplateHaskell #-}
-
+{-# LANGUAGE OverloadedStrings #-}
 module Templates where
 
+import GHC.Generics
 import Data.FileEmbed
 import System.FilePath ((</>))
+import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Encoding as LT
+import qualified Data.Text as T
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Aeson.Encode.Pretty
 
-packagesDhall :: String
+data PscPackage = PscPackage { name :: T.Text
+                             , set :: T.Text
+                             , source :: T.Text
+                             , depends :: [T.Text]
+                             }
+                  deriving (Show, Generic)
+$(deriveJSON defaultOptions ''PscPackage)
+
+packagesDhall :: T.Text
 packagesDhall = $(embedStringFile "templates/packages.dhall")
 
-pscPackageJson :: String
-pscPackageJson = $(embedStringFile "templates/psc-package.json")
+encodePscPackage :: PscPackage -> T.Text
+encodePscPackage = LT.toStrict . LT.decodeUtf8 . encodePretty
+
+pscPackageJson :: T.Text -> T.Text
+pscPackageJson name = encodePscPackage $ PscPackage name "local" "" []

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,8 @@ dependencies:
 - turtle
 - filepath
 - file-embed
+- aeson
+- aeson-pretty
 
 executables:
   spacchetti:

--- a/templates/psc-package.json
+++ b/templates/psc-package.json
@@ -1,6 +1,0 @@
-{
-  "name": "my-project",
-  "set": "local",
-  "source": "",
-  "depends": []
-}


### PR DESCRIPTION
This pr uses aeson to generate the `psc-package.json`.

In case there's an existing `psc-package.json` and `--force` is not used, `spacchetti local-setup` keeps the existing dependencies.

I also changed a bit some output lines, but I feel like they can improved a lot.

Now the workflow to create a new project is:

```
pulp --psc-package init
spacchetti local-setup
spacchetti insdhall
psc-package install
pulp build
```